### PR TITLE
ldap search filters - allow literal expression

### DIFF
--- a/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
+++ b/roles/cloudera_manager/external_auth/templates/external_auth_configs.j2
@@ -16,7 +16,7 @@ LDAP_DN_PATTERN: {{ auth_provider.ldap_dn_pattern | default(None) }}
 LDAP_GROUP_SEARCH_BASE: {{ auth_provider.ldap_search_base.group | default(None) }}
 {% if auth_provider.ldap_search_filter.group is defined %}
 LDAP_GROUP_SEARCH_FILTER: "({{ auth_provider.ldap_search_filter.group }}"
-{% else % }
+{% else %}
 LDAP_GROUP_SEARCH_FILTER: "({{ auth_provider.ldap_attribute.member | default('member') }}={0})"
 {% endif %}
 LDAP_TYPE: {{ auth_provider.type | cloudera.cluster.to_ldap_type_enum | default(None) }}


### PR DESCRIPTION
Older implementation assumed all ldap filters end with "={0}" This newer implementation allows the user to craft any legal filter expression, including complex compound expressions, like ((&(member={0})(objectclass=posixgroup)(!(cn=admin))) above is example IPA group search filter for ECS 1.5.x