### PR TITLE
Update postgresql-RedHat.yml

### DIFF
--- a/roles/infrastructure/rdbms/tasks/postgresql-RedHat.yml
+++ b/roles/infrastructure/rdbms/tasks/postgresql-RedHat.yml
@@ -19,7 +19,7 @@
     name: pgdg-common
     description: PostgreSQL common for RHEL/CentOS
     baseurl: https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-$releasever-$basearch
-    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    gpgkey: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
   when: not (skip_rdbms_repo_setup | default(False))
 
 - name: Install PostgreSQL version repository
@@ -27,7 +27,7 @@
     name: pgdg
     description: PostgreSQL {{ postgresql_version }} for RHEL/CentOS
     baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgresql_version }}/redhat/rhel-$releasever-$basearch
-    gpgkey: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    gpgkey: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
   when: not (skip_rdbms_repo_setup | default(False))
 
 - name: disable default Postgres module in Rhel 8


### PR DESCRIPTION
In Jan 2024, postgresql.org changed location of GPG keys